### PR TITLE
Normalize train mode handling across networks

### DIFF
--- a/python/jdet/models/networks/_training.py
+++ b/python/jdet/models/networks/_training.py
@@ -1,0 +1,28 @@
+"""Utilities shared across network wrappers for training mode handling."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def set_module_training_mode(module: Any, mode: bool) -> None:
+    """Best-effort setter for a submodule's training mode.
+
+    Some modules in the original Jittor-based codebase expose ``train`` without
+    accepting a boolean ``mode`` argument, whereas PyTorch expects
+    ``train(mode: bool)``.  This helper normalises the behaviour across both
+    implementations by attempting to call ``train`` with ``mode`` first and
+    falling back to a no-argument invocation when the signature is incompatible.
+    """
+
+    if module is None:
+        return
+
+    train_fn = getattr(module, "train", None)
+    if train_fn is None:
+        return
+
+    try:
+        train_fn(mode)
+    except TypeError:
+        train_fn()

--- a/python/jdet/models/networks/faster_rcnn_obb.py
+++ b/python/jdet/models/networks/faster_rcnn_obb.py
@@ -5,6 +5,8 @@ from jdet.ops.bbox_transforms import bbox2roi, dbbox2result
 import jittor as jt
 from jdet.utils.general import parse_losses
 
+from ._training import set_module_training_mode
+
 @MODELS.register_module()
 class FasterRCNNOBB(nn.Module):
 
@@ -199,8 +201,14 @@ class FasterRCNNOBBNew(nn.Module):
             det_result = self.bbox_head(features, proposal_list, targets)
             return det_result
 
-    def train(self):
-        super(FasterRCNNOBBNew, self).train()
+    def train(self, mode: bool = True):
+        try:
+            super(FasterRCNNOBBNew, self).train(mode)
+        except TypeError:
+            super(FasterRCNNOBBNew, self).train()
+
         for v in self.__dict__.values():
             if isinstance(v, nn.Module):
-                v.train()
+                set_module_training_mode(v, mode)
+
+        return self

--- a/python/jdet/models/networks/fcos.py
+++ b/python/jdet/models/networks/fcos.py
@@ -1,9 +1,21 @@
 from jdet.utils.registry import MODELS
+
+from ._training import set_module_training_mode
 from .single_stage import SingleStageDetector
 
 @MODELS.register_module()
 class FCOS(SingleStageDetector):
     
-    def train(self):
-        super().train()
-        self.backbone.train()
+    def train(self, mode: bool = True):
+        try:
+            super().train(mode)
+        except TypeError:
+            super().train()
+
+        set_module_training_mode(self.backbone, mode)
+        if getattr(self, "neck", None):
+            set_module_training_mode(self.neck, mode)
+        if getattr(self, "bbox_head", None):
+            set_module_training_mode(self.bbox_head, mode)
+
+        return self

--- a/python/jdet/models/networks/redet.py
+++ b/python/jdet/models/networks/redet.py
@@ -4,6 +4,8 @@ from jittor import nn
 from jdet.utils.registry import BOXES, MODELS, build_from_cfg, BACKBONES, HEADS, NECKS, ROI_EXTRACTORS
 from jdet.ops.bbox_transforms import bbox2roi, roi2droi, choose_best_Rroi_batch, dbbox2roi, dbbox2result
 
+from ._training import set_module_training_mode
+
 @MODELS.register_module()
 class ReDet(nn.Module):
     def __init__(self,
@@ -226,8 +228,14 @@ class ReDet(nn.Module):
         else:
             return self.execute_test(images, targets)
     
-    def train(self):
-        super(ReDet, self).train()
+    def train(self, mode: bool = True):
+        try:
+            super(ReDet, self).train(mode)
+        except TypeError:
+            super(ReDet, self).train()
+
         for v in self.__dict__.values():
             if isinstance(v, nn.Module):
-                v.train()
+                set_module_training_mode(v, mode)
+
+        return self

--- a/python/jdet/models/networks/roi_transformer.py
+++ b/python/jdet/models/networks/roi_transformer.py
@@ -5,6 +5,8 @@ from jdet.utils.registry import BOXES, MODELS, build_from_cfg, BACKBONES, HEADS,
 from jdet.ops.bbox_transforms import bbox2roi, gt_mask_bp_obbs_list, roi2droi, choose_best_Rroi_batch, dbbox2roi, dbbox2result
 import copy
 
+from ._training import set_module_training_mode
+
 @MODELS.register_module()
 class RoITransformer(nn.Module):
     def __init__(self,
@@ -250,8 +252,14 @@ class RoITransformerNew(nn.Module):
             det_result = self.rbbox_head(features, proposal_list, targets, as_proposals=False)
             return det_result
 
-    def train(self):
-        super(RoITransformerNew, self).train()
+    def train(self, mode: bool = True):
+        try:
+            super(RoITransformerNew, self).train(mode)
+        except TypeError:
+            super(RoITransformerNew, self).train()
+
         for v in self.__dict__.values():
             if isinstance(v, nn.Module):
-                v.train()
+                set_module_training_mode(v, mode)
+
+        return self

--- a/python/jdet/models/networks/rotated_retinanet.py
+++ b/python/jdet/models/networks/rotated_retinanet.py
@@ -3,6 +3,8 @@ from jittor import nn
 
 from jdet.utils.registry import MODELS,build_from_cfg,BACKBONES,HEADS,NECKS
 
+from ._training import set_module_training_mode
+
 
 @MODELS.register_module()
 class RotatedRetinaNet(nn.Module):
@@ -15,9 +17,19 @@ class RotatedRetinaNet(nn.Module):
         self.neck = build_from_cfg(neck,NECKS)
         self.bbox_head = build_from_cfg(bbox_head,HEADS)
 
-    def train(self):
-        super().train()
-        self.backbone.train()
+    def train(self, mode: bool = True):
+        try:
+            super().train(mode)
+        except TypeError:
+            super().train()
+
+        set_module_training_mode(self.backbone, mode)
+        if getattr(self, "neck", None):
+            set_module_training_mode(self.neck, mode)
+        if getattr(self, "bbox_head", None):
+            set_module_training_mode(self.bbox_head, mode)
+
+        return self
 
     def execute(self,images,targets):
         '''

--- a/python/jdet/models/networks/s2anet.py
+++ b/python/jdet/models/networks/s2anet.py
@@ -3,6 +3,8 @@ from jittor import nn
 
 from jdet.utils.registry import MODELS,build_from_cfg,BACKBONES,HEADS,NECKS
 
+from ._training import set_module_training_mode
+
 
 @MODELS.register_module()
 class S2ANet(nn.Module):
@@ -15,9 +17,19 @@ class S2ANet(nn.Module):
         self.neck = build_from_cfg(neck,NECKS)
         self.bbox_head = build_from_cfg(bbox_head,HEADS)
 
-    def train(self):
-        super().train()
-        self.backbone.train()
+    def train(self, mode: bool = True):
+        try:
+            super().train(mode)
+        except TypeError:
+            super().train()
+
+        set_module_training_mode(self.backbone, mode)
+        if getattr(self, "neck", None):
+            set_module_training_mode(self.neck, mode)
+        if getattr(self, "bbox_head", None):
+            set_module_training_mode(self.bbox_head, mode)
+
+        return self
 
     def execute(self,images,targets):
         '''


### PR DESCRIPTION
## Summary
- add a shared helper to normalize module.train handling between Jittor-style and PyTorch-style components
- update network wrappers to accept the optional mode flag and delegate to the helper when propagating train/eval state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e010c535c4832496c991d8e0ea3064